### PR TITLE
fix: ripristina i biglietti eventi sulle pagine prerenderizzate

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prerequisites: Node.js >= 22.12.0 and [pnpm](https://pnpm.io/).
    pnpm install
    ```
 
-3. (Optional) Create a `.env` file for the events/tickets integration (in production these values are read from Cloudflare KV; without them the tickets section is simply hidden):
+3. (Optional) Create a `.env` file for the events/tickets integration. Most pages are prerendered; the tickets block is a server island (`server:defer`) so it can still read Cloudflare KV at request time in production. Without these values (locally) or the matching KV keys (in production), the section is simply hidden:
 
    ```bash
    SECRET_LOAD_EVENTS=true

--- a/src/components/Tickets.astro
+++ b/src/components/Tickets.astro
@@ -1,8 +1,21 @@
 ---
 import { env } from "cloudflare:workers";
-import { getLangFromUrl, useTranslations } from "../i18n/utils";
+import {
+	DEFAULT_LANG,
+	getLangFromUrl,
+	useTranslations,
+	type UiType,
+} from "../i18n/utils";
 
-const lang = getLangFromUrl(Astro.url);
+interface Props {
+	/**
+	 * Required when rendered as a server island (`server:defer`): Astro.url is
+	 * `/_server-islands/...`, so language cannot be inferred from the pathname.
+	 */
+	lang?: UiType;
+}
+
+const lang = (Astro.props.lang ?? getLangFromUrl(Astro.url) ?? DEFAULT_LANG) as UiType;
 const t = useTranslations(lang);
 
 let events = [];
@@ -12,13 +25,14 @@ try {
 	let apiUsername: string | null = null;
 	let apiPassword: string | null = null;
 
-	// Try environment variables first (works for both dev and production)
+	// Try environment variables first (local .env / build-time secrets)
 	loadEvents = String(import.meta.env.SECRET_LOAD_EVENTS || "");
 	apiUrl = String(import.meta.env.SECRET_EVENTS_API_URL || "");
 	apiUsername = String(import.meta.env.SECRET_EVENTS_API_USERNAME || "");
 	apiPassword = String(import.meta.env.SECRET_EVENTS_API_PASSWORD || "");
 
-	// If env vars are not set, try Cloudflare KV
+	// Production: pages are prerendered, so secrets live in Cloudflare KV and
+	// this component must run on-demand (via server:defer) to read them.
 	if (
 		!loadEvents ||
 		loadEvents === "" ||

--- a/src/layouts/Insight.astro
+++ b/src/layouts/Insight.astro
@@ -157,7 +157,7 @@ const jsonLdExtra = [
     </div>
   </article>
 
-  <Tickets />
+  <Tickets lang={lang} server:defer />
 </BaseLayout>
 
 <style>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -325,7 +325,7 @@ const formatDate = (value: Date) =>
   }
   <!-- Recent Blog section end -->
 
-  <Tickets />
+  <Tickets lang={lang} server:defer />
 </BaseLayout>
 
 <style>

--- a/src/pages/[lang]/[servicesSection]/index.astro
+++ b/src/pages/[lang]/[servicesSection]/index.astro
@@ -235,7 +235,7 @@ const hubArticles = (await getInsights(lang))
     </div>
   </section>
 
-  <Tickets />
+  <Tickets lang={lang} server:defer />
 </BaseLayout>
 
 <style>

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -151,7 +151,7 @@ const jsonLdExtra = [
     </div>
   </div>
 
-  <Tickets />
+  <Tickets lang={lang} server:defer />
 </BaseLayout>
 
 <style>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -148,7 +148,7 @@ const serviceCatalog = services.map((service) => ({
 
   <Certifications />
 
-  <Tickets />
+  <Tickets lang={lang} server:defer />
 
   <script is:inline>
     (() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema
Dopo il passaggio a `prerender = true` (SEO/sitemap), il blocco biglietti in fondo alle pagine non compare più.

`Tickets.astro` legge i secret Eventitech da env locali oppure da Cloudflare KV a **runtime**. Con le pagine statiche il componente girava solo in **build**, senza KV → `events = []` → sezione omessa dall’HTML.

## Fix
- Carica `<Tickets />` come **server island** (`server:defer`) così il fetch avviene a request time sul Worker.
- Passa `lang` come prop (su un’island `Astro.url` è `/_server-islands/...`, non la pagina).
- Aggiorna il README sul comportamento production.

## Verifica
- `pnpm run build` ✅
- `pnpm run verify:seo` ✅ (68 pages, no regressions)
- HTML generato include preload/fetch verso `/_server-islands/Tickets`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faa03-e74e-741c-af0c-60a0ce71f1ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faa03-e74e-741c-af0c-60a0ce71f1ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

